### PR TITLE
I825 fix style 2

### DIFF
--- a/controllers/grid/catalogEntry/PublicationFormatGridCellProvider.inc.php
+++ b/controllers/grid/catalogEntry/PublicationFormatGridCellProvider.inc.php
@@ -145,7 +145,7 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 								'setApproved', null, array('representationId' => $data->getId(), 'newApprovedState' => $data->getIsApproved()?0:1, 'submissionId' => $monographId)),
 							'modal_approve'
 						),
-						$data->getIsApproved()?__('common.disable'):__('common.enable'),
+						$data->getIsApproved()?__('submission.catalogEntry'):__('submission.noCatalogEntry'),
 						$data->getIsApproved()?'complete':'incomplete',
 						__('grid.action.formatApproved')
 					));
@@ -159,7 +159,7 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 								'setAvailable', null, array('representationId' => $data->getId(), 'newAvailableState' => $data->getIsAvailable()?0:1, 'submissionId' => $monographId)),
 							'modal_approve'
 						),
-						$data->getIsAvailable()?__('common.disable'):__('common.enable'),
+						$data->getIsAvailable()?__('grid.catalogEntry.isAvailable'):__('grid.catalogEntry.isNotAvailable'),
 						$data->getIsAvailable()?'complete':'incomplete',
 						__('grid.action.formatAvailable')
 					));
@@ -176,10 +176,10 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 					AppLocale::requireComponents(LOCALE_COMPONENT_PKP_EDITOR);
 					import('lib.pkp.classes.linkAction.request.AjaxAction');
 					return array(new LinkAction(
-						$submissionFile->getViewable()?'disapprove':'approve',
+						$submissionFile->getViewable()?'approved':'not_approved',
 						new RemoteActionConfirmationModal(
 							__($submissionFile->getViewable()?'editor.submission.proofreading.confirmRemoveCompletion':'editor.submission.proofreading.confirmCompletion'),
-							__('editor.submission.proofreading.completionTitle'),
+							__($submissionFile->getViewable()?'editor.submission.proofreading.revokeProofApproval':'editor.submission.proofreading.approveProof'),
 							$router->url(
 								$request, null, null, 'setProofFileCompletion',
 								null,
@@ -192,9 +192,18 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 							),
 							'modal_approve'
 						),
-						$submissionFile->getViewable()?__('grid.action.disapprove'):__('grid.action.approve')
+						$submissionFile->getViewable()?__('grid.catalogEntry.availablePublicationFormat.approved'):__('grid.catalogEntry.availablePublicationFormat.notApproved')
 					));
 				case 'isAvailable':
+					$salesType = preg_replace('/[^\da-z]/i', '', $submissionFile->getSalesType());
+					$salesTypeString = 'editor.monograph.approvedProofs.edit.linkTitle';
+					if ($salesType == 'openAccess') {
+						$salesTypeString = 'payment.directSales.openAccess';
+					} elseif ($salesType == 'directSales') {
+						$salesTypeString = 'payment.directSales.directSales';
+					} elseif ($salesType == 'notAvailable') {
+						$salesTypeString = 'payment.directSales.notAvailable';
+					}
 					return array(new LinkAction(
 						'editApprovedProof',
 						new AjaxModal(
@@ -206,8 +215,8 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 							__('editor.monograph.approvedProofs.edit'),
 							'edit'
 						),
-						__('editor.monograph.approvedProofs.edit.linkTitle'),
-						preg_replace('/[^\da-z]/i', '', $submissionFile->getSalesType())
+						__($salesTypeString),
+						$salesType
 					));
 			}
 		}

--- a/controllers/grid/catalogEntry/PublicationFormatGridHandler.inc.php
+++ b/controllers/grid/catalogEntry/PublicationFormatGridHandler.inc.php
@@ -145,17 +145,17 @@ class PublicationFormatGridHandler extends CategoryGridHandler {
 				null,
 				'controllers/grid/common/cell/statusCell.tpl',
 				$this->_cellProvider,
-				array('width' => 20, 'alignment' => COLUMN_ALIGNMENT_CENTER)
+				array('width' => 20)
 			)
 		);
 		$this->addColumn(
 			new GridColumn(
 				'isAvailable',
-				'grid.catalogEntry.isAvailable',
+				'grid.catalogEntry.availability',
 				null,
 				'controllers/grid/common/cell/statusCell.tpl',
 				$this->_cellProvider,
-				array('width' => 20, 'alignment' => COLUMN_ALIGNMENT_CENTER)
+				array('width' => 20)
 			)
 		);
 	}

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -78,17 +78,21 @@
 	<message key="grid.catalogEntry.physicalFormat">Physical format</message>
 	<message key="grid.catalogEntry.monographRequired">A monograph id is required.</message>
 	<message key="grid.catalogEntry.publicationFormatRequired">A publication format must be chosen.</message>
+	<message key="grid.catalogEntry.availability">Availability</message>
 	<message key="grid.catalogEntry.isAvailable">Available</message>
+	<message key="grid.catalogEntry.isNotAvailable">Not Available</message>
 	<message key="grid.catalogEntry.proof">Proof</message>
 	<message key="grid.catalogEntry.approvedPublicationFormat.title">Format Approval</message>
-	<message key="grid.catalogEntry.approvedPublicationFormat.message"><![CDATA[<p>This format will now be marked <em>approved</em> and added to the catalog.]]></message>
-	<message key="grid.catalogEntry.approvedPublicationFormat.removeMessage"><![CDATA[<p>This format will <em>no longer be marked approved</em> and will be removed from the catalog.</p>]]></message>
+	<message key="grid.catalogEntry.approvedPublicationFormat.message"><![CDATA[<p>Add this format to the catalog entry.</p>]]></message>
+	<message key="grid.catalogEntry.approvedPublicationFormat.removeMessage"><![CDATA[<p>Remove this format from the catalog entry.</p>]]></message>
 	<message key="grid.catalogEntry.availablePublicationFormat.title">Format Availability</message>
-	<message key="grid.catalogEntry.availablePublicationFormat.message"><![CDATA[<p>This format will now be made <em>available</em> to readers, through downloadable files that will now appear with the book’s catalog entry and/or through further actions taken by the press to distribute the book.</p>]]></message>
-	<message key="grid.catalogEntry.availablePublicationFormat.removeMessage"><![CDATA[<p>This format will <em>no longer be made available</em> to readers, through downloadable files that previously appeared with the book’s catalog entry and/or through further actions taken by the press to distribute the book.</p>]]></message>
+	<message key="grid.catalogEntry.availablePublicationFormat.message"><![CDATA[<p>Make this format <em>available to readers</em>. Downloadable files and any other distributions will appear in the book's catalog entry.</p>]]></message>
+	<message key="grid.catalogEntry.availablePublicationFormat.removeMessage"><![CDATA[<p>This format will <em>unavailable to readers</em>. Any downloadable files or other distributions will no longer appear in the book's catalog entry.</p>]]></message>
 	<message key="grid.catalogEntry.availablePublicationFormat.catalogNotApprovedWarning">Catalog entry not approved.</message>
 	<message key="grid.catalogEntry.availablePublicationFormat.notApprovedWarning">Format not in catalog entry.</message>
 	<message key="grid.catalogEntry.availablePublicationFormat.proofNotApproved">Proof not approved.</message>
+	<message key="grid.catalogEntry.availablePublicationFormat.approved">Approved</message>
+	<message key="grid.catalogEntry.availablePublicationFormat.notApproved">Awaiting Approval</message>
 
 	<!--  publication metadata required form field keys -->
 	<message key="grid.catalogEntry.fileSizeRequired">A file size for digital formats required.</message>

--- a/locale/en_US/submission.xml
+++ b/locale/en_US/submission.xml
@@ -95,6 +95,7 @@
 
 	<!-- Submission-specific catalog info -->
 	<message key="submission.catalogEntry">Catalog Entry</message>
+	<message key="submission.noCatalogEntry">No Catalog Entry</message>
 	<message key="submission.editCatalogEntry">Entry</message>
 	<message key="submission.catalogEntry.new">New Catalog Entry</message>
 	<message key="submission.catalogEntry.confirm">Create a catalog entry for this book based on the metadata below.</message>

--- a/styles/index.less
+++ b/styles/index.less
@@ -36,6 +36,13 @@
         font-size: @font-base;
     }
 
+    .onix_code {
+        margin-left: 1em;
+        font-size: 12px;
+        color: @text-light;
+        font-weight: @normal;
+    }
+
     .pkp_controllers_grid .label.before_actions {
         display: block;
         margin: 0;

--- a/styles/index.less
+++ b/styles/index.less
@@ -36,6 +36,10 @@
         font-size: @font-base;
     }
 
+    .pkp_controllers_grid td {
+        line-height: 30px; // larger to fit our special buttons
+    }
+
     .onix_code {
         margin-left: 1em;
         font-size: 12px;
@@ -85,52 +89,100 @@
     }
 
     // Complete checkboxes
-    .pkp_linkaction_approve,
-    .pkp_linkaction_disapprove,
+    .pkp_linkaction_approved,
+    .pkp_linkaction_not_approved,
     .pkp_linkaction_approvePublicationFormat,
     .pkp_linkaction_availablePublicationFormat,
     .pkp_linkaction_editApprovedProof {
-        display: block;
-        margin: 0 auto;
-        width: @line-base;
-        height: @line-base;
-        line-height: @line-base;
-        overflow: hidden;
+        display: inline-block;
+        padding: 5px 1em;
+        border: 1px solid fade(@primary-lift, 60%);
+        border-radius: @radius;
+        font-size: 12px;
+        line-height: 20px;
+        text-decoration: none;
 
         &:before {
             &:extend(.fa);
+            margin-right:  0.5em;
         }
 
-        &.pkp_controllers_linkAction:hover:before,
-        &.pkp_controllers_linkAction:focus:before {
-            color: @primary-lift;
+        &:hover,
+        &:focus {
+            border-color: @primary-lift;
+            background: @primary-lift;
+            color: #fff;
+
+            &:before {
+                color: #fff;
+            }
         }
     }
 
-    .pkp_linkaction_approve:before,
+    .pkp_linkaction_icon_complete,
+    .pkp_linkaction_approved {
+        border-color: @yes;
+        background: @yes;
+        color: #fff;
+
+        &:before {
+            color: #fff;
+        }
+
+        &:hover,
+        &:focus {
+            border-color: @yes-lift;
+            background: @yes-lift;
+        }
+    }
+
+    .pkp_linkaction_not_approved:before,
     .pkp_linkaction_icon_incomplete:before {
         content: @fa-var-square-o;
     }
 
-    .pkp_linkaction_disapprove:before,
+    .pkp_linkaction_approved:before,
     .pkp_linkaction_icon_complete:before {
         content: @fa-var-check-square-o;
-        color: @yes;
     }
 
-    .pkp_linkaction_editApprovedProof:before,
-    .pkp_linkaction_editApprovedProof.pkp_linkaction_icon_notAvailable:before {
-        content: @fa-var-ban;
-        color: @no;
+    .pkp_linkaction_editApprovedProof.pkp_linkaction_icon_:before {
+        content: @fa-var-pencil;
+    }
+
+    .pkp_linkaction_editApprovedProof.pkp_linkaction_icon_notAvailable {
+        border-color: @no;
+        background: @no;
+        color: #fff;
+
+        &:before {
+            content: @fa-var-ban;
+            color: #fff;
+        }
+
+        &:hover,
+        &:focus {
+            background: @no-lift;
+        }
+    }
+
+    .pkp_linkaction_editApprovedProof.pkp_linkaction_icon_openAccess,
+    .pkp_linkaction_editApprovedProof.pkp_linkaction_icon_directSales {
+        border-color: @yes;
+        background: @yes;
+        color: #fff;
+
+        &:hover,
+        &:focus {
+            background: @yes-lift;
+        }
     }
 
     .pkp_linkaction_editApprovedProof.pkp_linkaction_icon_openAccess:before {
         content: @fa-var-unlock-alt;
-        color: @yes;
     }
 
     .pkp_linkaction_editApprovedProof.pkp_linkaction_icon_directSales:before {
         content: @fa-var-money;
-        color: @primary-lift;
     }
 }

--- a/styles/index.less
+++ b/styles/index.less
@@ -43,7 +43,7 @@
         font-weight: @normal;
     }
 
-    .pkp_controllers_grid .label.before_actions {
+    .pkp_controllers_grid .category .label.before_actions {
         display: block;
         margin: 0;
         padding: 0;


### PR DESCRIPTION
Ok, had a bit of a brainstorm and came up with this slightly more button-looking toggle system for the approvals. It gives us a bit of text to use to describe each button, as well as more of an encompassing visual indication of button toggles.

![new-approvals](https://cloud.githubusercontent.com/assets/2306629/10637478/d3e37698-77fd-11e5-9387-e8cafabe5b5f.png)

In addition to this, I adjusted a bunch of the actual text we're using. For the button labels, I've opted to consistently focus on "status". Now that the buttons look more clickable, I think we can gear the language to status and rely on people to click to change the status.

The confirmation modals you implemented really improve things, I think. For all the confirmation modals, I swapped to a particular language approach, which describes plainly and directly the action that's about to occur. This is just a slight change from the existing approach, which was more of a "Are you sure you want to?" I hope the confirmation modals as they are are more clear about what's happening, slightly more direct, but also more concise.
