### PR TITLE
pkp/pkp-lib#805 Clean up footer styles

### DIFF
--- a/plugins/themes/default/styles/footer.less
+++ b/plugins/themes/default/styles/footer.less
@@ -23,41 +23,21 @@
 		padding-bottom: @triple;
 	}
 
-	.categories,
 	.page_footer {
 		padding: @base;
 		background: @lift;
-	}
 
-	.category {
-		margin-bottom: @triple;
+		> *:first-child {
+			margin-top: 0;
+		}
 
-		&:last-child {
+		> *:last-child {
 			margin-bottom: 0;
-		}
-
-		h4 {
-			margin: 0;
-			font-size: @font-sml;
-			line-height: @double;
-		}
-
-		ul {
-			margin: 0;
-			padding: 0;
-			list-style: none;
-		}
-
-		li {
-			padding: 4px 0;
-			font-size: @font-sml;
-			line-height: @line-base;
 		}
 	}
 
 	@media(min-width: @screen-phone) {
 
-		.categories,
 		.page_footer {
 			padding: @double;
 		}
@@ -70,37 +50,18 @@
 			background: @bg;
 		}
 
-		.categories {
-			.pkp_helpers_clear;
-			padding: 30px 0 0;
-		}
-
-		.category {
-			float: left;
-			width: 50%;
-			padding: @double;
-		}
-
-		.categories_3 .category {
-			width: 33%;
-		}
-
 		.page_footer {
-			padding: @triple
+			padding: @triple;
 		}
 	}
 
 	// 3 categories per row
 	@media(min-width: @screen-desktop) {
 
-		.categories,
 		.page_footer {
+			min-height: @logo-height + (@triple * 2);
 			margin-left: @sidebar-width;
 			border-top: @bg-border;
-		}
-
-		.category {
-			padding: @triple;
 		}
 	}
 }

--- a/plugins/themes/default/styles/footer.less
+++ b/plugins/themes/default/styles/footer.less
@@ -43,7 +43,6 @@
 		}
 	}
 
-	// 2 categories per row
 	@media(min-width: @screen-tablet) {
 
 		.pkp_structure_footer {
@@ -55,7 +54,6 @@
 		}
 	}
 
-	// 3 categories per row
 	@media(min-width: @screen-desktop) {
 
 		.page_footer {


### PR DESCRIPTION
Removes some styles no longer needed and ensures a page footer will be flush with a logo on the bottom if present.
